### PR TITLE
Add missing import in pyai_caching/__init__.py

### DIFF
--- a/src/pyai_caching/__init__.py
+++ b/src/pyai_caching/__init__.py
@@ -2,7 +2,7 @@
 LLM Caching - Redis-based caching for LLM agents with cost tracking
 """
 
-from .agent import cached_agent_run
+from .agent import cached_agent_run, cached_agent_run_sync
 from .types import ExpenseRecorder
 from .costs import ModelCosts, DEFAULT_COSTS
 from .config import ConfigurationError


### PR DESCRIPTION
`cached_agent_run_sync` is listed among the available attributes but is not actually imported and available for use.
This PR fixes the import statement 
https://github.com/talkingtoaj/PydanticAI-llm-caching/blob/8e63141cce325b676b86461734cdc79a9cb6da06/src/pyai_caching/__init__.py#L5-L14